### PR TITLE
feat(pcg): add new pcg brew

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,259 @@
+# Installing from homebrew-forge (Private Tap)
+
+This guide explains how to install tools from the `benbenbang/homebrew-forge` private Homebrew tap.
+
+## Prerequisites
+
+### 1. Access Requirements
+
+- **GitHub account** with access to this private repository
+- **SSH key configured** for GitHub authentication
+- **Git credentials** properly set up
+
+```bash
+# Verify GitHub access
+ssh -T git@github.com
+# Should return: "Hi username! You've successfully authenticated..."
+```
+
+### 2. Required Software
+
+- **Homebrew** - macOS/Linux package manager
+- **Git** - Version control (usually pre-installed)
+
+```bash
+# Install Homebrew if not already installed
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+## Authentication Setup
+
+### Create GitHub Personal Access Token
+
+1. Go to [GitHub Settings → Developer Settings → Personal Access Tokens](https://github.com/settings/tokens)
+2. Click **"Generate new token (classic)"**
+3. Set **Expiration** (recommend 90 days or longer)
+4. Select these **permissions**:
+   - ✅ `repo` (Full control of private repositories)
+   - ✅ `read:packages` (Read packages)
+5. Click **"Generate token"**
+6. **Copy the token** immediately (you won't see it again!)
+
+### Configure Environment
+
+Add your token to your shell profile:
+
+```bash
+# For zsh (macOS default)
+echo 'export HOMEBREW_GITHUB_API_TOKEN="your_token_here"' >> ~/.zshrc
+source ~/.zshrc
+
+# For bash
+echo 'export HOMEBREW_GITHUB_API_TOKEN="your_token_here"' >> ~/.bash_profile
+source ~/.bash_profile
+```
+
+**⚠️ Security Note**: Keep your token secure and never commit it to code repositories.
+
+## Installation
+
+### Step 1: Add the Private Tap
+
+```bash
+# Add the private tap using SSH (recommended for private repos)
+brew tap benbenbang/forge git@github.com:benbenbang/homebrew-forge.git
+```
+
+### Step 2: Install Tools
+
+```bash
+# Install preconf-cli (pre-commit configuration generator)
+brew install preconf-cli
+
+# Verify installation
+pcg --help
+```
+
+## Available Tools
+
+### preconf-cli (pcg)
+
+Pre-commit configuration generator for development workflows.
+
+```bash
+# Install
+brew install preconf-cli
+
+# Usage
+pcg --help
+pcg init    # Generate pre-commit configuration
+```
+
+## Usage Examples
+
+### Basic Usage
+
+```bash
+# Generate a new pre-commit configuration
+pcg init
+
+# Use with specific project types
+pcg init --type golang
+pcg init --type python
+pcg init --type node
+```
+
+### Integration with Projects
+
+```bash
+# In your project directory
+cd my-project
+pcg init
+git add .pre-commit-config.yaml
+git commit -m "Add pre-commit configuration"
+
+# Install pre-commit hooks
+pre-commit install
+```
+
+## Updating
+
+### Update the Tap
+
+```bash
+# Update tap to get latest formulas
+brew update
+
+# Upgrade installed packages
+brew upgrade preconf-cli
+```
+
+### Update Tools
+
+```bash
+# Upgrade specific tool
+brew upgrade preconf-cli
+
+# Upgrade all tools from this tap
+brew upgrade benbenbang/forge/preconf-cli
+```
+
+## Troubleshooting
+
+### Common Issues
+
+#### ❌ "Authentication failed"
+
+```bash
+# Verify token is set
+echo $HOMEBREW_GITHUB_API_TOKEN
+
+# Re-export token if needed
+export HOMEBREW_GITHUB_API_TOKEN="your_token_here"
+```
+
+#### ❌ "Permission denied"
+
+```bash
+# Verify SSH access to GitHub
+ssh -T git@github.com
+
+# Re-add tap if needed
+brew untap benbenbang/forge
+brew tap benbenbang/forge git@github.com:benbenbang/homebrew-forge.git
+```
+
+#### ❌ "Formula not found"
+
+```bash
+# Update tap
+brew update
+
+# List available formulas
+brew search benbenbang/forge/
+```
+
+#### ❌ "Checksum mismatch"
+
+This usually means the release binaries have been updated but the formula hasn't. Please:
+
+1. Check if there's a newer version available
+2. Report the issue to the maintainer
+3. Try reinstalling: `brew uninstall preconf-cli && brew install preconf-cli`
+
+### Getting Help
+
+1. **Check the logs**:
+   ```bash
+   brew install --verbose --debug preconf-cli
+   ```
+
+2. **Verify tap status**:
+   ```bash
+   brew tap-info benbenbang/forge
+   ```
+
+3. **Clean and retry**:
+   ```bash
+   brew cleanup
+   brew doctor
+   ```
+
+## Removing
+
+### Uninstall Tools
+
+```bash
+# Uninstall specific tool
+brew uninstall preconf-cli
+
+# Remove tap entirely
+brew untap benbenbang/forge
+```
+
+## Development
+
+### For Contributors
+
+If you're contributing to this tap:
+
+```bash
+# Clone the repository
+git clone git@github.com:benbenbang/homebrew-forge.git
+cd homebrew-forge
+
+# Build forge CLI
+make build
+
+# Test formulas
+./bin/forge validate preconf-cli
+```
+
+### Local Testing
+
+```bash
+# Test formula locally without installing
+brew audit --new Formula/preconf-cli.rb
+
+# Install from local file
+brew install --build-from-source Formula/preconf-cli.rb
+```
+
+## Security
+
+- **Never share your GitHub token**
+- **Use tokens with minimal necessary permissions**
+- **Rotate tokens regularly (every 90 days)**
+- **Revoke tokens when no longer needed**
+
+## Support
+
+- **Issues**: Open an issue on the GitHub repository
+- **Questions**: Start a discussion on GitHub
+- **Documentation**: Check the main [README.md](README.md)
+
+---
+
+**Built with ❤️ by [benbenbang](https://github.com/benbenbang)**
+
+*Making development workflows easier, one tool at a time.*

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ make build
 
 ### Example Formulas
 
+- **preconf-cli** - Pre-commit configuration generator (complete example)
 - **tomlv** - TOML validator tool (working example)
 
 ## Installation
@@ -78,14 +79,18 @@ make build
 ### Install via Homebrew Tap
 
 ```bash
+# Set up GitHub authentication (required for private repo)
+export HOMEBREW_GITHUB_API_TOKEN="your_github_token"
+
 # Add the private tap (requires GitHub access)
-brew tap benbenbang/forge
+brew tap benbenbang/forge git@github.com:benbenbang/homebrew-forge.git
 
 # Install forge
 brew install forge
 
 # Install example tools
-brew install tomlv
+brew install preconf-cli  # Pre-commit configuration generator
+brew install tomlv        # TOML validator
 ```
 
 ## Usage

--- a/formula/preconf-cli/pcg.rb
+++ b/formula/preconf-cli/pcg.rb
@@ -1,0 +1,94 @@
+# GitHubPrivateRepositoryReleaseDownloadStrategy downloads tarballs from GitHub
+# Release assets. To use it, add `:using => :github_private_release` to the URL section
+# of your formula. This download strategy uses GitHub access tokens (in the
+# environment variables HOMEBREW_GITHUB_API_TOKEN) to sign the request.
+class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDownloadStrategy
+  def initialize(url, name, version, **meta)
+    super
+  end
+
+  def parse_url_pattern
+    url_pattern = %r{https://github.com/([^/]+)/([^/]+)/releases/download/([^/]+)/(\S+)}
+    unless @url =~ url_pattern
+      raise CurlDownloadStrategyError, "Invalid url pattern for GitHub Release."
+    end
+
+    _, @owner, @repo, @tag, @filename = *@url.match(url_pattern)
+  end
+
+  def download_url
+    "https://api.github.com/repos/#{@owner}/#{@repo}/releases/assets/#{asset_id}"
+  end
+
+  private
+
+  def _fetch(url:, resolved_url:, timeout:)
+    # HTTP request header `Accept: application/octet-stream` is required.
+    # Without this, the GitHub API will respond with metadata, not binary.
+    curl_download download_url, "--header", "Accept: application/octet-stream", "--header", "Authorization: token #{@github_token}", to: temporary_path
+  end
+
+  def asset_id
+    @asset_id ||= resolve_asset_id
+  end
+
+  def resolve_asset_id
+    release_metadata = fetch_release_metadata
+    assets = release_metadata["assets"].select { |a| a["name"] == @filename }
+    raise CurlDownloadStrategyError, "Asset file not found." if assets.empty?
+
+    assets.first["id"]
+  end
+
+  def fetch_release_metadata
+    release_url = "https://api.github.com/repos/#{@owner}/#{@repo}/releases/tags/#{@tag}"
+    GitHub::API.open_rest(release_url)
+  end
+end
+
+# Formula for pcg - Pre-commit configuration generator
+class Pcg < Formula
+  desc "Pre-commit configuration generator for development workflows"
+  homepage "https://github.com/benbenbang/preconf-cli"
+  version "1.0.2"
+  license "MIT"
+
+  # Default to macOS Intel
+  url "https://github.com/benbenbang/preconf-cli/releases/download/v1.0.2/pcg-darwin-amd64",
+      using: GitHubPrivateRepositoryReleaseDownloadStrategy
+  sha256 "2588644d6a59349a8e8250313d6c6b37c5307ed3a23638636d83a29ab7a4ff93"
+
+  # Platform-specific binaries
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/benbenbang/preconf-cli/releases/download/v1.0.2/pcg-darwin-arm64",
+          using: GitHubPrivateRepositoryReleaseDownloadStrategy
+      sha256 "bfcab23acc1ae9c67d48eadd4524375404fa74dfa12e36c22fa18c32b07c56dc"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.intel?
+      url "https://github.com/benbenbang/preconf-cli/releases/download/v1.0.2/pcg-linux-amd64",
+          using: GitHubPrivateRepositoryReleaseDownloadStrategy
+      sha256 "43c004573cdcefbaea26e8a4bce11259fa48a666ff8e4032f2678bb4796d382f"
+    elsif Hardware::CPU.arm?
+      url "https://github.com/benbenbang/preconf-cli/releases/download/v1.0.2/pcg-linux-arm64",
+          using: GitHubPrivateRepositoryReleaseDownloadStrategy
+      sha256 "2a05a9ad69c7e7625482829cc3c68f1f0dd37e1c717c53d07d1fcfb7719bd69e"
+    end
+  end
+
+  def install
+    # Install the pcg binary
+    bin.install "pcg-#{OS.kernel_name.downcase}-#{Hardware::CPU.arch}" => "pcg"
+  end
+
+  test do
+    # Test that the binary runs and shows help
+    assert_match "pcg", shell_output("#{bin}/pcg --help")
+
+    # Test version command if available
+    # assert_match version.to_s, shell_output("#{bin}/pcg --version")
+  end
+end


### PR DESCRIPTION
This pull request introduces a new tool, `preconf-cli`, to the private Homebrew tap and provides comprehensive documentation and implementation for its installation, usage, and development. It includes updates to the `INSTALL.md` and `README.md` files and adds a new formula file for `preconf-cli` with a custom download strategy for private GitHub repositories.

### Documentation Updates:
* Added a detailed installation guide for the `benbenbang/homebrew-forge` private tap, including prerequisites, authentication setup, and usage examples for `preconf-cli` in `INSTALL.md`.
* Updated `README.md` to include `preconf-cli` as an example formula and provide installation instructions with GitHub authentication for the private tap. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R82-R93)

### Formula Implementation:
* Created a new formula file `formula/preconf-cli/pcg.rb` for `preconf-cli`, which includes platform-specific binaries, a custom `GitHubPrivateRepositoryReleaseDownloadStrategy` for secure downloads, and installation and test instructions.