### PR TITLE
refactor(tap): update mermaid-ascii install method

### DIFF
--- a/Formula/mermaid-ascii.rb
+++ b/Formula/mermaid-ascii.rb
@@ -24,15 +24,8 @@ class MermaidAscii < Formula
   end
 
   def install
-    # Since we're downloading the binary directly, we need to handle it properly
-    # The cached_download gives us the path to the downloaded file
-    binary_path = cached_download
-
-    # Make it executable
-    chmod 0755, binary_path
-
-    # Install the binary
-    bin.install binary_path => "mermaid-ascii"
+    # Extract the tar.gz file and install the binary
+    bin.install "mermaid-ascii"
   end
 
   test do


### PR DESCRIPTION
This pull request makes a small update to the installation process for the `mermaid-ascii` Homebrew formula. The change simplifies the `install` method by directly installing the binary from the extracted tarball, removing unnecessary steps.

* Simplified the `install` method in `Formula/mermaid-ascii.rb` to directly install the `mermaid-ascii` binary, eliminating manual extraction and permission setting.