### PR TITLE
feat(formula): add new formula for kute repo

### DIFF
--- a/Formula/kubectl-nuke.rb
+++ b/Formula/kubectl-nuke.rb
@@ -1,0 +1,49 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Include the custom download strategy
+require_relative "../scripts/github_prv_repo_download_strategy"
+
+# Formula for kubectl-nuke - Delete Kubernetes resources with filtering options
+class KubectlNuke < Formula
+  desc "Delete Kubernetes resources with filtering options"
+  homepage "https://github.com/benbenbang/kute"
+  version "1.1.0"
+  license "Proprietary"
+
+  # Platform-specific URLs using the custom download strategy
+  if OS.mac? && Hardware::CPU.arm?
+    url "https://github.com/benbenbang/kute/releases/download/#{version}/kubectl-nuke-darwin-arm64",
+        using: GitHubPrivateRepositoryReleaseDownloadStrategy
+    sha256 "82baa46c3b19626949576fe103911a39016809a5a3849d9a937bbf0b245f3bf1"
+  elsif OS.mac? && Hardware::CPU.intel?
+    url "https://github.com/benbenbang/kute/releases/download/#{version}/kubectl-nuke-darwin-amd64",
+        using: GitHubPrivateRepositoryReleaseDownloadStrategy
+    sha256 "b2664bd89abc7337f19271e71e7064047c24599125e4cda1e191de9a18a322ad"
+  elsif OS.linux? && Hardware::CPU.arm?
+    url "https://github.com/benbenbang/kute/releases/download/#{version}/kubectl-nuke-linux-arm64",
+        using: GitHubPrivateRepositoryReleaseDownloadStrategy
+    sha256 "23c94c990939b0d006f4758d4a112e5e09601ea81f806ea3757b553918e753b1"
+  elsif OS.linux? && Hardware::CPU.intel?
+    url "https://github.com/benbenbang/kute/releases/download/#{version}/kubectl-nuke-linux-amd64",
+        using: GitHubPrivateRepositoryReleaseDownloadStrategy
+    sha256 "0f3a4a1230fed62d74316910ccd8100a2a3499b52c2d8d627ffdbbd8e1bb8435"
+  end
+
+  def install
+    # Since we're downloading the binary directly, we need to handle it properly
+    # The cached_download gives us the path to the downloaded file
+    binary_path = cached_download
+
+    # Make it executable
+    chmod 0755, binary_path
+
+    # Install the binary
+    bin.install binary_path => "kubectl-nuke"
+  end
+
+  test do
+    # Test that the binary runs and shows help
+    assert_match "kubectl-nuke", shell_output("#{bin}/kubectl-nuke --help")
+  end
+end

--- a/Formula/kubectl-obj-transform.rb
+++ b/Formula/kubectl-obj-transform.rb
@@ -1,0 +1,49 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Include the custom download strategy
+require_relative "../scripts/github_prv_repo_download_strategy"
+
+# Formula for kubectl-obj-transform - Transform Kubernetes secrets or configmaps to .env format
+class KubectlObjTransform < Formula
+  desc "Transform Kubernetes secrets or configmaps to .env format"
+  homepage "https://github.com/benbenbang/kute"
+  version "1.1.0"
+  license "Proprietary"
+
+  # Platform-specific URLs using the custom download strategy
+  if OS.mac? && Hardware::CPU.arm?
+    url "https://github.com/benbenbang/kute/releases/download/#{version}/kubectl-obj_transform-darwin-arm64",
+        using: GitHubPrivateRepositoryReleaseDownloadStrategy
+    sha256 "5a809255435d2d9857c03527aa722d274591ad956354796879ba2a1e955a0506"
+  elsif OS.mac? && Hardware::CPU.intel?
+    url "https://github.com/benbenbang/kute/releases/download/#{version}/kubectl-obj_transform-darwin-amd64",
+        using: GitHubPrivateRepositoryReleaseDownloadStrategy
+    sha256 "6bb82b6d6695dca9b637fa574e37ad81071e6c3482f2342a3c46c47eb4b809c2"
+  elsif OS.linux? && Hardware::CPU.arm?
+    url "https://github.com/benbenbang/kute/releases/download/#{version}/kubectl-obj_transform-linux-arm64",
+        using: GitHubPrivateRepositoryReleaseDownloadStrategy
+    sha256 "5fb5fbb2660c05e8f80bad80374d0e4aec41ed61eec147680c4504b66f3231e0"
+  elsif OS.linux? && Hardware::CPU.intel?
+    url "https://github.com/benbenbang/kute/releases/download/#{version}/kubectl-obj_transform-linux-amd64",
+        using: GitHubPrivateRepositoryReleaseDownloadStrategy
+    sha256 "d38a6b543e949a2ec3376a45c1858cd2a04eb14be9c125e331a7f5f2f0387034"
+  end
+
+  def install
+    # Since we're downloading the binary directly, we need to handle it properly
+    # The cached_download gives us the path to the downloaded file
+    binary_path = cached_download
+
+    # Make it executable
+    chmod 0755, binary_path
+
+    # Install the binary
+    bin.install binary_path => "kubectl-obj-transform"
+  end
+
+  test do
+    # Test that the binary runs and shows help
+    assert_match "kubectl-obj-transform", shell_output("#{bin}/kubectl-obj-transform --help")
+  end
+end


### PR DESCRIPTION
This pull request adds two new Homebrew formulae for custom Kubernetes CLI tools, enabling users to easily install and manage these utilities via Homebrew. Each formula uses a custom download strategy to fetch platform-specific binaries from a private GitHub repository and includes basic installation and testing logic.

**New Homebrew Formulae for Kubernetes Tools:**

* Added `kubectl-nuke` formula for deleting Kubernetes resources with filtering options, supporting both macOS and Linux (ARM and Intel), and using a custom download strategy for private GitHub releases. (`Formula/kubectl-nuke.rb`)
* Added `kubectl-obj-transform` formula for transforming Kubernetes secrets or configmaps to `.env` format, with platform-specific binaries and custom download strategy. (`Formula/kubectl-obj-transform.rb`)

**Platform-Specific Installation Logic:**

* Each formula detects the operating system and CPU architecture to select the appropriate binary and SHA256 checksum for installation. [[1]](diffhunk://#diff-222cd11730eb5ea68085c757d129dcda6ba5307e6bf6c6c22cf6b4a50770cd53R1-R49) [[2]](diffhunk://#diff-21b29573d377ede186883fcc194314f491e867010f409110c0094d4843df867dR1-R49)

**Testing and Validation:**

* Both formulae include a test block to verify that the installed binary runs and displays help output. [[1]](diffhunk://#diff-222cd11730eb5ea68085c757d129dcda6ba5307e6bf6c6c22cf6b4a50770cd53R1-R49) [[2]](diffhunk://#diff-21b29573d377ede186883fcc194314f491e867010f409110c0094d4843df867dR1-R49)