### PR TITLE
fix(kube): replace dash to underscore

### DIFF
--- a/Formula/kubectl-obj-transform.rb
+++ b/Formula/kubectl-obj-transform.rb
@@ -39,11 +39,11 @@ class KubectlObjTransform < Formula
     chmod 0755, binary_path
 
     # Install the binary
-    bin.install binary_path => "kubectl-obj-transform"
+    bin.install binary_path => "kubectl-obj_transform"
   end
 
   test do
     # Test that the binary runs and shows help
-    assert_match "kubectl-obj-transform", shell_output("#{bin}/kubectl-obj-transform --help")
+    assert_match "kubectl-obj_transform", shell_output("#{bin}/kubectl-obj_transform --help")
   end
 end


### PR DESCRIPTION
This pull request updates the installation and test steps for the `kubectl-obj-transform` Homebrew formula to use an underscore in the binary name instead of a hyphen.

* Installation script: Changed the installed binary name from `kubectl-obj-transform` to `kubectl-obj_transform` in the `bin.install` step.
* Test script: Updated the test to reference `kubectl-obj_transform` instead of `kubectl-obj-transform` when checking the help output.