### PR TITLE
refactor(pcg): fix pcg sha256 issue

### DIFF
--- a/Formula/pcg.rb
+++ b/Formula/pcg.rb
@@ -15,19 +15,19 @@ class Pcg < Formula
   if OS.mac? && Hardware::CPU.arm?
     url "https://github.com/benbenbang/prjconf-cli/releases/download/#{version}/pcg-darwin-arm64",
         using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 "7ee6ba5bda679ecdf70e28775c909e0beafa68ea8c77118e09522cec91eb30ca"
+    sha256 "06e7101f6c213af85507ce6ac8a44953821a735ba8a56eb995614be33fbd9517"
   elsif OS.mac? && Hardware::CPU.intel?
     url "https://github.com/benbenbang/prjconf-cli/releases/download/#{version}/pcg-darwin-amd64",
         using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 "96fb2fba25bc8cc7e29d4d56d485b1f5e82594aea51c122aa2d5f13b5ada9daa"
+    sha256 "be7f652970fc1b86df64b7fd74df846af22483854b8d35ac3e756018ca35072f"
   elsif OS.linux? && Hardware::CPU.arm?
     url "https://github.com/benbenbang/prjconf-cli/releases/download/#{version}/pcg-linux-arm64",
         using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 "7ee6ba5bda679ecdf70e28775c909e0beafa68ea8c77118e09522cec91eb30ca"
+    sha256 "6a27c2e906cc588a47d8036547fc30c46306fb2945a21b7527ba5588e3bf318b"
   elsif OS.linux? && Hardware::CPU.intel?
     url "https://github.com/benbenbang/prjconf-cli/releases/download/#{version}/pcg-linux-amd64",
         using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 "7ee6ba5bda679ecdf70e28775c909e0beafa68ea8c77118e09522cec91eb30ca"
+    sha256 "adc4c3c91204187312fa923fc0242b460ae4280d4a3163aa86d91c5e8f87fe12"
   end
 
   def install

--- a/Formula/pcg@1.4.0.rb
+++ b/Formula/pcg@1.4.0.rb
@@ -15,19 +15,19 @@ class Pcg < Formula
   if OS.mac? && Hardware::CPU.arm?
     url "https://github.com/benbenbang/prjconf-cli/releases/download/#{version}/pcg-darwin-arm64",
         using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 "7ee6ba5bda679ecdf70e28775c909e0beafa68ea8c77118e09522cec91eb30ca"
+    sha256 "06e7101f6c213af85507ce6ac8a44953821a735ba8a56eb995614be33fbd9517"
   elsif OS.mac? && Hardware::CPU.intel?
     url "https://github.com/benbenbang/prjconf-cli/releases/download/#{version}/pcg-darwin-amd64",
         using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 "96fb2fba25bc8cc7e29d4d56d485b1f5e82594aea51c122aa2d5f13b5ada9daa"
+    sha256 "be7f652970fc1b86df64b7fd74df846af22483854b8d35ac3e756018ca35072f"
   elsif OS.linux? && Hardware::CPU.arm?
     url "https://github.com/benbenbang/prjconf-cli/releases/download/#{version}/pcg-linux-arm64",
         using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 "7ee6ba5bda679ecdf70e28775c909e0beafa68ea8c77118e09522cec91eb30ca"
+    sha256 "6a27c2e906cc588a47d8036547fc30c46306fb2945a21b7527ba5588e3bf318b"
   elsif OS.linux? && Hardware::CPU.intel?
     url "https://github.com/benbenbang/prjconf-cli/releases/download/#{version}/pcg-linux-amd64",
         using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 "7ee6ba5bda679ecdf70e28775c909e0beafa68ea8c77118e09522cec91eb30ca"
+    sha256 "adc4c3c91204187312fa923fc0242b460ae4280d4a3163aa86d91c5e8f87fe12"
   end
 
   def install


### PR DESCRIPTION
This pull request updates the SHA256 checksums for the `pcg` binary downloads in both `Formula/pcg.rb` and `Formula/pcg@1.4.0.rb`. These changes ensure that Homebrew verifies the integrity of the newly released binaries for all supported platforms and architectures.

Checksum updates for binary downloads:

* Updated the SHA256 checksums for `pcg-darwin-arm64`, `pcg-darwin-amd64`, `pcg-linux-arm64`, and `pcg-linux-amd64` in both `Formula/pcg.rb` and `Formula/pcg@1.4.0.rb` to match the latest release artifacts.