### PR TITLE
chore(pcg): update version to 1.5.0

### DIFF
--- a/Formula/pcg.rb
+++ b/Formula/pcg.rb
@@ -8,7 +8,7 @@ require_relative "../scripts/github_prv_repo_download_strategy"
 class Pcg < Formula
   desc "Project configuration generator for development workflows"
   homepage "https://github.com/benbenbang/prjconf-cli"
-  version "1.4.1"
+  version "1.5.0"
   license "Proprietary"
 
   # Platform-specific URLs using the custom download strategy


### PR DESCRIPTION
This pull request updates the version of the `pcg` formula to ensure users receive the latest release.

* Version bump:
  * Updated the `version` field in `Formula/pcg.rb` from `1.4.1` to `1.5.0` to distribute the new release.