### PR TITLE
feat(homebrew): update csl formula to version 1.10.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+A Homebrew tap (`brew tap benbenbang/forge`) hosting formulas for various CLI tools. Formulas live in `Formula/` and are written in Ruby following Homebrew conventions.
+
+## Updating a formula
+
+The primary workflow is `package.rb` — a Ruby script that fetches release asset checksums from GitHub and patches the formula file in-place.
+
+### Binary release (pre-built binaries)
+
+```bash
+# Update version + SHA256s
+./package.rb --assets benbenbang/consilium -f Formula/csl.rb -v 1.3.0
+
+# Update SHA256s only (no version bump)
+./package.rb --assets benbenbang/consilium -f Formula/csl.rb
+```
+
+### Source build (git revision)
+
+```bash
+# Update version + git revision SHA
+./package.rb --revision benbenbang/uv-shell -f Formula/uv-shell.rb -v 2.0.0
+```
+
+`package.rb` calls the `gh` CLI under the hood — a working `gh auth login` is required.
+
+## Formula architecture
+
+Two patterns are used across formulas:
+
+**Inline platform conditionals** (`Formula/csl.rb`, `Formula/pcg.rb`) — the `if OS.mac? && Hardware::CPU.arm?` chain appears directly in the formula body, with each branch providing its own `url` and `sha256`. Private repos use `GitHubPrivateRepositoryReleaseDownloadStrategy` (from `scripts/github_prv_repo_download_strategy.rb`), which reads the GitHub token from `HOMEBREW_GITHUB_API_TOKEN` or `GITHUB_TOKEN`.
+
+**Source builds** (`Formula/uv-shell.rb`) — clone from a git tag + revision, build with `cargo`/`go`/etc., then install.
+
+**`FormulaHelper` abstraction** (`scripts/formula_helper.rb`) — `BinaryConfig` / `SourceConfig` classes + `setup_binary` / `setup_source` class methods. Used in `examples/` and available for new formulas; reduces repetition when adding multi-platform binaries.
+
+## Generating a new formula
+
+```bash
+# Binary formula scaffold
+ruby scripts/generate_formula.rb binary owner/repo 1.0.0 binary-name [--private]
+
+# Source formula scaffold
+ruby scripts/generate_formula.rb source owner/repo 1.0.0 [--go|--rust|--npm] [--revision SHA]
+```
+
+Output is printed to stdout — redirect to `Formula/<name>.rb`.
+
+## Commit message format
+
+Pre-commit enforces conventional commits:
+
+```
+<type>(<scope>): <description>
+```
+
+Types: `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `style`, `test`, `revert`, `hotfix`, `ops`, `chore`
+
+## CI checks
+
+PRs against `main` run:
+- **pre-commit** hooks (yaml, trailing whitespace, JSON formatting, commit message validation)
+- **verify-change-sha**: fails if `Formula/*.rb` changed but no `sha256` line was modified — add the `skip-sha-check` label to bypass for non-checksum PRs

--- a/Formula/csl.rb
+++ b/Formula/csl.rb
@@ -8,26 +8,26 @@ require_relative "../scripts/github_prv_repo_download_strategy"
 class Csl < Formula
   desc "Consilium CLI for development workflows"
   homepage "https://github.com/benbenbang/consilium"
-  version "1.9.1"
+  version "1.10.0"
   license "Proprietary"
 
   # Platform-specific URLs using the custom download strategy
   if OS.mac? && Hardware::CPU.arm?
     url "https://github.com/benbenbang/consilium/releases/download/#{version}/csl-darwin-arm64",
         using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 "e46e31016dcb724b27bf100e32b18f72f7e9c8c68d6c8adc81f3c5789fb01eb0"
+    sha256 "5a77e4231305a16cd0df8f2734238ca091f702f5b0f2b81c6e9478624e2c23ad"
   elsif OS.mac? && Hardware::CPU.intel?
     url "https://github.com/benbenbang/consilium/releases/download/#{version}/csl-darwin-amd64",
         using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 "92ce6473b1ff106770e62c686d28ef41ece6d2710d8c55a304e7c44f13e0599c"
+    sha256 "136f2a23497c90a2f747cc3f6c68c0d4f7933b6fe483e1c55f71d4df6f01577e"
   elsif OS.linux? && Hardware::CPU.arm?
     url "https://github.com/benbenbang/consilium/releases/download/#{version}/csl-linux-arm64",
         using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 "ecf3eab9871371867e72b4934bac0b29bd63c066f2b9ada6e83bfb973f6340ac"
+    sha256 "da46b8224333f7b90df2986c0797a5a19dbf69647114933c972e5850307992ba"
   elsif OS.linux? && Hardware::CPU.intel?
     url "https://github.com/benbenbang/consilium/releases/download/#{version}/csl-linux-amd64",
         using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 "4eee50a1e3a8a4e849730c57cffa5c6c085da803e6fd75897c3b801063392cc4"
+    sha256 "a2b76c3dd5069bff60d53d869df9b30f289acbfd6ec84e92234c6ac1de29101d"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -10,22 +10,15 @@ brew install benbenbang/forge/tomlv
 utilize the `package.rb`
 
 Examples:
-```ruby
-# Specify both file and version
-gh release view --assets owner/repo --json "assets" --jq ".assets" | \
-  ./package.rb --file Formula/csl.rb --version 1.3.0
+```bash
+# Update version + SHA256s (binary release)
+./package.rb --assets benbenbang/consilium -f Formula/csl.rb -v 1.3.0
 
-# Short flags
-gh release view --assets owner/repo --json "assets" --jq ".assets" | \
-  ./package.rb -f Formula/csl.rb -v 1.3.0
+# Update SHA256s only, no version bump
+./package.rb --assets benbenbang/consilium -f Formula/csl.rb
 
-# Auto-detect file, just update version
-gh release view --assets owner/repo --json "assets" --jq ".assets" | \
-  ./package.rb -v 1.3.0
-
-# Just update digests, don't touch version
-gh release view --assets owner/repo --json "assets" --jq ".assets" | \
-  ./package.rb -f Formula/csl.rb
+# Update git revision for source build
+./package.rb --revision benbenbang/uv-shell -f Formula/uv-shell.rb -v 2.0.0
 
 # Show help
 ./package.rb --help


### PR DESCRIPTION
This pull request updates the Homebrew formula for the Consilium CLI (csl) to version 1.10.0, refreshes SHA256 checksums for all platform binaries, and improves documentation for the package update workflow.

**Formula version update:**
* Bumped csl formula version from 1.9.1 to 1.10.0 in Formula/csl.rb
* Updated SHA256 checksums for all four platform-specific binaries (darwin-arm64, darwin-amd64, linux-arm64, linux-amd64) to match the new release artifacts

**Documentation improvements:**
* Added new CLAUDE.md file for project-specific documentation
* Simplified and clarified package.rb usage examples in README.md, replacing verbose multi-line commands with concise single-line examples
* Updated examples to show both binary release updates (--assets flag) and source build updates (--revision flag) for better clarity
* Consolidated example commands from 4 verbose examples to 3 clear, practical use cases