### PR TITLE
feat(Formula): bump pcg version to 1.10.1

### DIFF
--- a/Formula/pcg.rb
+++ b/Formula/pcg.rb
@@ -8,26 +8,26 @@ require_relative "../scripts/github_prv_repo_download_strategy"
 class Pcg < Formula
   desc "Project configuration generator for development workflows"
   homepage "https://github.com/benbenbang/prjconf-cli"
-  version "1.9.0"
+  version "1.10.1"
   license "Proprietary"
 
   # Platform-specific URLs using the custom download strategy
   if OS.mac? && Hardware::CPU.arm?
     url "https://github.com/benbenbang/prjconf-cli/releases/download/#{version}/pcg-darwin-arm64",
         using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 "3638c9995ddeef9250960b7e674503a9888fce3c37b35414b13cee21ac9fbd80"
+    sha256 "52f0187361dc2743a8c80340f07f5ac5ac6ad80276461d622cd9f11de9c61123"
   elsif OS.mac? && Hardware::CPU.intel?
     url "https://github.com/benbenbang/prjconf-cli/releases/download/#{version}/pcg-darwin-amd64",
         using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 "dbdb57fba0def0cb28eb5717ea58751b92025a407c81a8c342cb2c2897ed8112"
+    sha256 "9033c1a28efc851f2fd87269fed0830c9be78e6332094606237949988be51100"
   elsif OS.linux? && Hardware::CPU.arm?
     url "https://github.com/benbenbang/prjconf-cli/releases/download/#{version}/pcg-linux-arm64",
         using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 "7f41803ce5c8fd0b60e3b8253206eda4ed9cf9acdfd7ae45dc1e7f4224641cbd"
+    sha256 "4d7e9bd7e6a014fca838b21e2ce30aa8f3b22d2c3187f17b19379afabea51b45"
   elsif OS.linux? && Hardware::CPU.intel?
     url "https://github.com/benbenbang/prjconf-cli/releases/download/#{version}/pcg-linux-amd64",
         using: GitHubPrivateRepositoryReleaseDownloadStrategy
-    sha256 "2700643465b20847c451cf2e404633c6c4153a9a7c145f67bf34b5df53749779"
+    sha256 "38f7be3270ca71838a9b66ba7cf96617383c6b66528d88b1a82ba11a391bee9c"
   end
 
   def install


### PR DESCRIPTION
This commit updates the Homebrew formula for the pcg (Project Configuration Generator) tool to version 1.10.1, updating all platform-specific binary checksums accordingly.

**Version and checksum updates:**
* Bumped version from 1.8.0 to 1.10.1 in the formula definition
* Updated SHA256 checksums for all supported platforms (macOS ARM64/AMD64 and Linux ARM64/AMD64) to match the new release binaries