### PR TITLE
chore(Formula): bump version to 2.6.2

### DIFF
--- a/Formula/uv-shell.rb
+++ b/Formula/uv-shell.rb
@@ -6,8 +6,8 @@ class UvShell < Formula
   desc "Create and activate Python virtual environments with uv"
   homepage "https://github.com/benbenbang/uv-shell"
   url "https://github.com/benbenbang/uv-shell.git",
-      tag:      "2.6.1",
-      revision: "68d5cd3fc0d7ab2d93535546a284d7bd2bdcc054"
+      tag:      "2.6.2",
+      revision: "ff2896bd339c8c642a0baacf0a10a9f6a5f0f08e"
   license "MIT"
   head "https://github.com/benbenbang/uv-shell.git", branch: "main"
 


### PR DESCRIPTION
This commit updates the Homebrew formula to reference version 2.6.2 of uv-shell. The changes update the release tag and corresponding git revision hash to point to the latest version.

**Version update:**
* Updated the formula tag from "2.6.1" to "2.6.2"
* Updated the git revision hash from "68d5cd3fc0d7ab2d93535546a284d7bd2bdcc054" to "ff2896bd339c8c642a0baacf0a10a9f6a5f0f08e"