### PR TITLE
feat(cask): add cask support with cask.rb updater script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-A Homebrew tap (`brew tap benbenbang/forge`) hosting formulas for various CLI tools. Formulas live in `Formula/` and are written in Ruby following Homebrew conventions.
+A Homebrew tap (`brew tap benbenbang/forge`) hosting formulas for various CLI tools and casks for macOS apps. Formulas live in `Formula/`, casks in `Casks/`, both written in Ruby following Homebrew conventions.
 
 ## Updating a formula
 
@@ -29,6 +29,20 @@ The primary workflow is `package.rb` — a Ruby script that fetches release asse
 
 `package.rb` calls the `gh` CLI under the hood — a working `gh auth login` is required.
 
+## Updating a cask
+
+Casks (macOS apps shipped as `.dmg`/`.pkg`/`.zip`) use `cask.rb` instead of `package.rb` — see [docs/cask_usage.md](docs/cask_usage.md). It reads the release asset's sha256 from GitHub and patches the cask in place.
+
+```bash
+# Update version + sha256
+./cask.rb benbenbang/cclog -f Casks/cclog.rb -v 1.1.0
+
+# Update sha256 only (no version bump)
+./cask.rb benbenbang/cclog -f Casks/cclog.rb
+```
+
+A separate script is warranted because casks differ from formulae: `sha256` precedes `url`, the filename is usually `#{version}`-interpolated, and there's typically one universal artifact. `cask.rb` pairs each `url` to its nearest `sha256`, so arch-split `on_arm`/`on_intel` casks update correctly too.
+
 ## Formula architecture
 
 Two patterns are used across formulas:
@@ -38,6 +52,10 @@ Two patterns are used across formulas:
 **Source builds** (`Formula/uv-shell.rb`) — clone from a git tag + revision, build with `cargo`/`go`/etc., then install.
 
 **`FormulaHelper` abstraction** (`scripts/formula_helper.rb`) — `BinaryConfig` / `SourceConfig` classes + `setup_binary` / `setup_source` class methods. Used in `examples/` and available for new formulas; reduces repetition when adding multi-platform binaries.
+
+## Cask architecture
+
+Casks distribute pre-built macOS apps. They reuse the same `GitHubPrivateRepositoryReleaseDownloadStrategy` as private formulae via `using:` on the `url` (drop it for public repos). Conventions: `sha256` before `url`, `#{version}`-interpolated filename, `desc` must not contain the platform word, `depends_on macos:` uses the bare-symbol minimum (e.g. `:catalina`), and `zap trash:` lists app-managed files. Notarized apps install without quarantine workarounds. Template: [examples/cask_example.rb](examples/cask_example.rb). End users (and the maintainer) need `HOMEBREW_GITHUB_API_TOKEN`/`GITHUB_TOKEN` to install a private cask.
 
 ## Generating a new formula
 
@@ -65,4 +83,4 @@ Types: `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `style`, `test`
 
 PRs against `main` run:
 - **pre-commit** hooks (yaml, trailing whitespace, JSON formatting, commit message validation)
-- **verify-change-sha**: fails if `Formula/*.rb` changed but no `sha256` line was modified — add the `skip-sha-check` label to bypass for non-checksum PRs
+- **verify-change-sha**: fails if `Formula/*.rb` changed but no `sha256` line was modified — add the `skip-sha-check` label to bypass for non-checksum PRs. Scoped to `Formula/**/*.rb` only, so cask-only PRs (`Casks/**/*.rb`) don't trigger it.

--- a/Casks/cclog.rb
+++ b/Casks/cclog.rb
@@ -1,0 +1,27 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Include the custom download strategy for private GitHub release assets
+require_relative "../scripts/github_prv_repo_download_strategy"
+
+cask "cclog" do
+  version "1.0.0"
+  sha256 "4dd550b3af28975d5598a3ce6fd6c2f64d0bb92e1cdd69cdaa74ebc7ce81cb68"
+
+  url "https://github.com/benbenbang/cclog/releases/download/#{version}/CCLog_#{version}_universal.dmg",
+      using: GitHubPrivateRepositoryReleaseDownloadStrategy
+  name "CCLog"
+  desc "Native app for reading Claude Code session logs"
+  homepage "https://github.com/benbenbang/cclog"
+
+  depends_on macos: :catalina
+
+  app "CCLog.app"
+
+  zap trash: [
+    "~/Library/Application Support/dev.bitbrew.cclog",
+    "~/Library/Caches/dev.bitbrew.cclog",
+    "~/Library/Preferences/dev.bitbrew.cclog.plist",
+    "~/Library/Saved Application State/dev.bitbrew.cclog.savedState",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -4,9 +4,18 @@
 
 ```bash
 brew tap benbenbang/forge
+
+# Formula (CLI tool)
 brew install benbenbang/forge/tomlv
+
+# Cask (macOS app)
+brew install --cask benbenbang/forge/cclog
 ```
-## To update the formula
+
+> Private formulae/casks need a token with repo access:
+> `export HOMEBREW_GITHUB_API_TOKEN="$(gh auth token)"`
+
+## To update a formula
 utilize the `package.rb`
 
 Examples:
@@ -22,4 +31,18 @@ ruby ./package.rb --revision benbenbang/uv-shell -f Formula/uv-shell.rb -v 2.0.0
 
 # Show help
 ruby ./package.rb --help
+```
+
+## To update a cask
+utilize the `cask.rb` (see [docs/cask_usage.md](docs/cask_usage.md))
+
+```bash
+# Bump version + refresh sha256 from the new release
+ruby cask.rb benbenbang/cclog -f Casks/cclog.rb -v 1.1.0
+
+# Refresh sha256 only, no version bump
+ruby cask.rb benbenbang/cclog -f Casks/cclog.rb
+
+# Show help
+ruby cask.rb --help
 ```

--- a/cask.rb
+++ b/cask.rb
@@ -1,0 +1,244 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# cask.rb — update a Homebrew Cask's version + sha256 from GitHub release assets.
+#
+# Casks distribute pre-built macOS artifacts (.dmg/.pkg/.zip). Unlike package.rb
+# (which handles formula binaries and source builds), this script is purpose-built
+# for casks: it bumps the `version` line and refreshes each `sha256` by reading the
+# checksum straight from the GitHub release asset metadata — no manual `shasum`.
+#
+# Usage:
+#   ./cask.rb OWNER/REPO -f Casks/<name>.rb -v <version>   # bump version + sha256
+#   ./cask.rb OWNER/REPO -f Casks/<name>.rb                # refresh sha256 only
+#
+# Example:
+#   ./cask.rb benbenbang/cclog -f Casks/cclog.rb -v 1.1.0
+
+require 'json'
+require 'optparse'
+
+options = { cask_file: nil, version: nil, repo: nil }
+
+parser = OptionParser.new do |opts|
+  opts.banner = "Usage: #{$PROGRAM_NAME} OWNER/REPO [options]"
+  opts.separator ""
+  opts.separator "Options:"
+
+  opts.on("-f", "--file CASK", "Path to the cask file (auto-detected from Casks/ if omitted)") do |file|
+    options[:cask_file] = file
+  end
+
+  opts.on("-v", "--version VERSION", "Version to set in the cask (omit to refresh sha256 only)") do |version|
+    options[:version] = version
+  end
+
+  opts.on("-h", "--help", "Show this help message") do
+    puts opts
+    puts ""
+    puts "Examples:"
+    puts "  # Bump version + refresh sha256 from the new release"
+    puts "  #{$PROGRAM_NAME} benbenbang/cclog -f Casks/cclog.rb -v 1.1.0"
+    puts ""
+    puts "  # Refresh sha256 only (re-uploaded asset, same version)"
+    puts "  #{$PROGRAM_NAME} benbenbang/cclog -f Casks/cclog.rb"
+    exit 0
+  end
+end
+parser.parse!
+
+options[:repo] = ARGV[0]
+
+# ---- validation -------------------------------------------------------------
+
+if options[:repo].nil?
+  warn "Error: Repository (owner/repo) is required. Use -h for help."
+  exit 1
+end
+
+unless options[:repo].match?(%r{^[\w\-.]+/[\w\-.]+$})
+  warn "Error: Repository must be in format 'owner/repo'"
+  exit 1
+end
+
+# Auto-detect a single cask under Casks/ if not given explicitly.
+def find_cask_file
+  files = Dir.glob('Casks/*.rb')
+  return files.first if files.length == 1
+
+  if files.empty?
+    warn "Error: No cask file found under Casks/. Specify one with -f."
+  else
+    warn "Error: Multiple cask files found. Specify one with -f:"
+    files.each { |f| warn "  - #{f}" }
+  end
+  nil
+end
+
+cask_path = options[:cask_file] || find_cask_file
+exit 1 if cask_path.nil?
+
+unless File.exist?(cask_path)
+  warn "Error: Cask file '#{cask_path}' not found"
+  exit 1
+end
+
+unless system('which gh > /dev/null 2>&1')
+  warn "Error: GitHub CLI (gh) is not installed or not in PATH (brew install gh)"
+  exit 1
+end
+
+# ---- fetch release asset checksums -----------------------------------------
+
+# Returns { "asset-file-name" => "sha256hex", ... } for the release.
+def fetch_release_assets(repo, version)
+  puts "📦 Fetching release assets from #{repo}..."
+
+  output = nil
+  tag_found = nil
+
+  if version
+    # Releases are tagged either "v1.2.3" or "1.2.3" — try both.
+    ["v#{version}", version].each do |tag|
+      output = `gh release view #{tag} --repo #{repo} --json assets --jq '.assets' 2>&1`
+      if $?.success?
+        tag_found = tag
+        break
+      end
+    end
+
+    unless tag_found
+      warn "Error: Could not find release 'v#{version}' or '#{version}' in #{repo}"
+      warn "Available releases:"
+      system("gh release list --repo #{repo} --limit 5")
+      exit 1
+    end
+    puts "✓ Found release: #{tag_found}"
+  else
+    output = `gh release view --repo #{repo} --json assets --jq '.assets' 2>&1`
+    unless $?.success?
+      warn "Error: Failed to fetch latest release from GitHub"
+      warn output
+      exit 1
+    end
+    puts "✓ Using latest release"
+  end
+
+  begin
+    assets = JSON.parse(output)
+  rescue JSON::ParserError => e
+    warn "Error parsing GitHub response: #{e.message}"
+    exit 1
+  end
+
+  digest_map = {}
+  assets.each do |asset|
+    digest = asset.dig('digest')&.sub('sha256:', '')
+    digest_map[asset['name']] = digest if digest && !digest.empty?
+  end
+
+  if digest_map.empty?
+    warn "Error: No SHA256 digests found in release assets."
+    warn "GitHub computes asset digests automatically; ensure the release has uploaded artifacts."
+    exit 1
+  end
+
+  digest_map
+end
+
+# ---- patching ---------------------------------------------------------------
+
+# Build the set of names an asset might appear as inside the cask's url line:
+#   - the literal name as uploaded:            CCLog_1.0.0_universal.dmg
+#   - the version-templated form (interpolated): CCLog_#{version}_universal.dmg
+# Matching either keeps both styles of cask working.
+def name_variants(asset_name, version)
+  variants = [asset_name]
+  variants << asset_name.sub(version, '#{version}') if version && asset_name.include?(version)
+  variants.uniq
+end
+
+# Pair each release asset to a sha256 line and replace it.
+#
+# Casks conventionally write `sha256` *before* `url` (and arch-split casks repeat the
+# pair inside on_arm/on_intel blocks). Rather than match across lines with regex —
+# which risks pairing one block's sha256 with another block's url — we locate each
+# `url` by its asset filename, then bind it to the *nearest* sha256 line. Only assets
+# actually referenced by a url are touched, so extra release artifacts
+# (checksums.txt, other-platform builds, ...) are ignored safely.
+def update_shas(content, digest_map, version)
+  lines = content.lines
+
+  sha_re = /^\s*sha256\s+"([a-f0-9]{64})"/
+  sha_idxs = lines.each_index.select { |i| lines[i] =~ sha_re }
+
+  # Find the url line for each asset (by literal or #{version}-templated filename).
+  url_for = {}
+  digest_map.each_key do |asset_name|
+    names = name_variants(asset_name, version)
+    idx = lines.each_index.find do |i|
+      lines[i] =~ /^\s*url\s+"/ && names.any? { |n| lines[i].include?(n) }
+    end
+    url_for[asset_name] = idx if idx
+  end
+
+  # Greedily bind each url to its nearest unclaimed sha256 line.
+  claimed = {}
+  updates = []
+  url_for.sort_by { |_, url_idx| url_idx }.each do |asset_name, url_idx|
+    sha_idx = sha_idxs.reject { |i| claimed[i] }
+                      .min_by { |i| (i - url_idx).abs }
+    next unless sha_idx
+
+    claimed[sha_idx] = true
+    old_digest = lines[sha_idx][sha_re, 1]
+    new_digest = digest_map[asset_name]
+    lines[sha_idx] = lines[sha_idx].sub(/"[a-f0-9]{64}"/, "\"#{new_digest}\"")
+    updates << { name: asset_name, old: old_digest, new: new_digest }
+  end
+
+  [updates, lines.join]
+end
+
+# ---- main -------------------------------------------------------------------
+
+content = File.read(cask_path)
+
+current_version = content[/version\s+"([^"]+)"/, 1]
+unless current_version
+  warn "Error: Could not find a `version \"...\"` line in #{cask_path}"
+  exit 1
+end
+
+# The version that release assets are named/tagged with.
+effective_version = options[:version] || current_version
+
+digest_map = fetch_release_assets(options[:repo], options[:version])
+
+# Bump the version line (and any literal version inside url lines, for non-interpolated casks).
+if options[:version] && options[:version] != current_version
+  content.gsub!(/(version\s+)"[^"]+"/, "\\1\"#{options[:version]}\"")
+  content.gsub!(/(url\s+"[^"]*)#{Regexp.escape(current_version)}/, "\\1#{options[:version]}")
+  puts "✓ Version: #{current_version} → #{options[:version]}"
+end
+
+updates, content = update_shas(content, digest_map, effective_version)
+
+if updates.empty?
+  warn "Warning: No sha256 values updated."
+  warn "Check that the cask's url filename matches a release asset (literal or #{'#{version}'}-templated)."
+  exit 1
+end
+
+File.write(cask_path, content)
+
+puts "✓ Cask '#{cask_path}' updated successfully!"
+puts "\n📝 Updated #{updates.length} checksum(s):"
+updates.each do |u|
+  if u[:old] == u[:new]
+    puts "  • #{u[:name]} (unchanged)"
+  else
+    puts "  ✓ #{u[:name]}"
+    puts "    #{u[:old][0..15]}... → #{u[:new][0..15]}..."
+  end
+end

--- a/docs/cask_usage.md
+++ b/docs/cask_usage.md
@@ -1,0 +1,109 @@
+# cask.rb Usage Guide
+
+`cask.rb` updates a Homebrew **Cask** the same way `package.rb` updates a formula —
+it reads the release asset checksum straight from GitHub and patches the cask file
+in place. It's a separate script (not a `package.rb` mode) because casks differ from
+formulae in three ways: `sha256` comes *before* `url`, the filename is usually
+`#{version}`-interpolated, and there's typically a single universal artifact.
+
+## When to use a cask vs. a formula
+
+| Distribute… | Use | Lives in |
+|-------------|-----|----------|
+| A CLI tool / library (binary or source build) | **Formula** + `package.rb` | `Formula/` |
+| A pre-built macOS app (`.dmg`/`.pkg`/`.zip`) | **Cask** + `cask.rb` | `Casks/` |
+
+A tap hosts both at once; no extra setup beyond creating the `Casks/` directory.
+
+## Usage
+
+```bash
+# Bump version + refresh sha256 from the new release
+ruby cask.rb benbenbang/cclog -f Casks/cclog.rb -v 1.1.0
+
+# Refresh sha256 only (asset re-uploaded under the same version)
+ruby cask.rb benbenbang/cclog -f Casks/cclog.rb
+
+# Auto-detect the cask (only one file under Casks/)
+ruby cask.rb benbenbang/cclog -v 1.1.0
+
+# Help
+ruby cask.rb --help
+```
+
+**What it does:**
+1. Fetches release assets via `gh release view` and reads each asset's `digest`
+   (GitHub computes the sha256 automatically — no manual `shasum`).
+2. Bumps the `version "…"` line (and rewrites a literal version in the `url`, for
+   casks that don't interpolate `#{version}`).
+3. Pairs each release asset to a `sha256` line by locating its `url` (matching the
+   literal **or** `#{version}`-templated filename) and binding it to the nearest
+   `sha256` — which respects the cask `sha256`-before-`url` order and keeps
+   arch-split `on_arm`/`on_intel` blocks from cross-pairing.
+4. Only touches assets actually referenced by a `url`, so extra release files
+   (`checksums.txt`, other-platform builds) are ignored.
+
+## Example
+
+```bash
+ruby cask.rb benbenbang/cclog -f Casks/cclog.rb -v 1.1.0
+```
+
+```
+📦 Fetching release assets from benbenbang/cclog...
+✓ Found release: 1.1.0
+✓ Version: 1.0.0 → 1.1.0
+✓ Cask 'Casks/cclog.rb' updated successfully!
+
+📝 Updated 1 checksum(s):
+  ✓ CCLog_1.1.0_universal.dmg
+    4dd550b3af28975d... → <new digest>...
+```
+
+## Writing the cask
+
+See [`examples/cask_example.rb`](../examples/cask_example.rb) for a full template.
+Key points:
+
+- **Interpolate the version in the url** (`CCLog_#{version}_universal.dmg`) so a bump
+  only touches `version` + `sha256`.
+- **Private repos** reuse the tap's download strategy — add
+  `require_relative "../scripts/github_prv_repo_download_strategy"` at the top and
+  `using: GitHubPrivateRepositoryReleaseDownloadStrategy` on the `url`. For public
+  repos, drop both and Homebrew downloads directly.
+- **`desc` must not contain the platform** (e.g. no "macOS") — `brew style` fails otherwise.
+- **`depends_on macos:`** uses the bare symbol form for a minimum (`:catalina` is the
+  oldest symbol current Homebrew accepts).
+- **`zap trash:`** lists app-managed files (keyed by the app's bundle id) removed on
+  `brew uninstall --zap`.
+
+## Requirements
+
+- GitHub CLI (`gh`) installed and authenticated (`gh auth status`).
+- For a **private** cask, both the maintainer running `cask.rb` and end users running
+  `brew install --cask` need a `HOMEBREW_GITHUB_API_TOKEN` (or `GITHUB_TOKEN`) with
+  read access to the release repo — same as the tap's private formulae.
+
+## Validate before committing
+
+```bash
+# Style + online audit (downloads + verifies the asset). For a private cask, export a token first:
+HOMEBREW_GITHUB_API_TOKEN="$(gh auth token)" brew audit --cask --online benbenbang/forge/<name>
+brew style Casks/<name>.rb
+git diff Casks/<name>.rb
+```
+
+> A cask-only PR does **not** trip the `verify-change-sha` CI check — that check is
+> scoped to `Formula/**/*.rb`.
+
+## Troubleshooting
+
+**Warning: No sha256 values updated**
+- The cask's `url` filename doesn't match any release asset. Check the asset name on
+  the release vs. the `url` (remember `#{version}` expands to the version).
+
+**Error: No SHA256 digests found in release assets**
+- The release has no uploaded artifacts, or they're still processing.
+
+**`brew install --cask` fails to download (private repo)**
+- Token missing or lacks access: `export HOMEBREW_GITHUB_API_TOKEN="$(gh auth token)"`.

--- a/examples/cask_example.rb
+++ b/examples/cask_example.rb
@@ -1,0 +1,52 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Example: macOS app cask distributing a .dmg from a GitHub release.
+#
+# Casks (in Casks/) distribute pre-built macOS artifacts — .dmg/.pkg/.zip — as
+# opposed to formulae (in Formula/), which build/install CLI tools. A tap can host
+# both at once. Install with:  brew install --cask benbenbang/forge/<name>
+#
+# Keep the version out of the filename by interpolating #{version} in the url; that
+# way `cask.rb -v <new>` only has to touch the `version` and `sha256` lines.
+
+# --- Private repo: reuse the tap's GitHub token download strategy --------------
+# Drop this require line for a PUBLIC repo (no auth needed) and Homebrew downloads
+# the release asset directly.
+require_relative "../scripts/github_prv_repo_download_strategy"
+
+cask "example-app" do
+  version "1.0.0"
+  sha256 "0" * 64 # sha256 of the .dmg — `cask.rb` fills this from the release asset
+
+  url "https://github.com/owner/repo/releases/download/#{version}/ExampleApp_#{version}_universal.dmg",
+      using: GitHubPrivateRepositoryReleaseDownloadStrategy # omit `using:` for public repos
+  name "Example App"
+  desc "One-line description without the word macOS" # `desc` may not contain the platform
+  homepage "https://github.com/owner/repo"
+
+  depends_on macos: :catalina # minimum macOS (oldest symbol Homebrew still accepts)
+
+  app "Example App.app" # the .app bundle inside the mounted DMG
+
+  # Clean up app-managed files on `brew uninstall --zap`. Use the app's bundle id.
+  zap trash: [
+    "~/Library/Application Support/com.example.app",
+    "~/Library/Caches/com.example.app",
+    "~/Library/Preferences/com.example.app.plist",
+    "~/Library/Saved Application State/com.example.app.savedState",
+  ]
+end
+
+# --- Arch-split variant (when there's no universal build) ----------------------
+# Replace the single url/sha256 above with per-arch blocks; `cask.rb` pairs each
+# url to its nearest sha256, so both checksums update correctly:
+#
+#   on_arm do
+#     sha256 "..."
+#     url ".../ExampleApp_#{version}_aarch64.dmg", using: GitHubPrivateRepositoryReleaseDownloadStrategy
+#   end
+#   on_intel do
+#     sha256 "..."
+#     url ".../ExampleApp_#{version}_x86_64.dmg", using: GitHubPrivateRepositoryReleaseDownloadStrategy
+#   end


### PR DESCRIPTION
This pull request introduces Homebrew cask support to the tap, adding a dedicated updater script and accompanying documentation. The main changes enable distributing pre-built macOS apps alongside the existing CLI formulae.

**Cask updater script:**
* Added `cask.rb`, a Ruby script that reads a release asset's sha256 from GitHub and patches a cask file in place. Unlike `package.rb`, it accounts for cask conventions: `sha256` precedes `url`, filenames are `#{version}`-interpolated, and each `url` is paired to its nearest `sha256` so arch-split `on_arm`/`on_intel` casks update correctly.
* Supports both version bumps (`-v`) and sha256-only refreshes.

**New cask and examples:**
* Added `Casks/cclog.rb` as the first cask in the tap.
* Added `examples/cask_example.rb` as a template for new casks, reusing `GitHubPrivateRepositoryReleaseDownloadStrategy` for private repos.

**Documentation:**
* Added `docs/cask_usage.md` documenting the cask workflow.
* Updated `CLAUDE.md` and `README.md` to cover cask installation, updating, conventions, and the `HOMEBREW_GITHUB_API_TOKEN` requirement.
* Noted that `verify-change-sha` is scoped to `Formula/**/*.rb` so cask-only PRs do not trigger it.