### PR TITLE
fix(Casks): quit cclog app before uninstall

### DIFF
--- a/Casks/cclog.rb
+++ b/Casks/cclog.rb
@@ -18,6 +18,8 @@ cask "cclog" do
 
   app "CCLog.app"
 
+  uninstall quit: "dev.bitbrew.cclog"
+
   zap trash: [
     "~/Library/Application Support/dev.bitbrew.cclog",
     "~/Library/Caches/dev.bitbrew.cclog",


### PR DESCRIPTION
Added an `uninstall quit` stanza to the cclog cask so the running application is properly terminated before removal. This ensures a clean uninstall by stopping the `dev.bitbrew.cclog` process, preventing potential issues with leftover running instances during cask removal.