### PR TITLE
fix(Casks): handle LoadError for download strategy on upgrade

### DIFF
--- a/Casks/cclog.rb
+++ b/Casks/cclog.rb
@@ -1,8 +1,20 @@
 # typed: strict
 # frozen_string_literal: true
 
-# Include the custom download strategy for private GitHub release assets
-require_relative "../scripts/github_prv_repo_download_strategy"
+# Include the custom download strategy for private GitHub release assets.
+# On `brew upgrade`, Homebrew copies this cask file alone into the Caskroom
+# receipt (without the sibling scripts/ dir) and loads it to run the old
+# version's uninstall — so require_relative fails there with a LoadError.
+# Fall back to a stub so the receipt still loads: uninstall never downloads,
+# it only quits and removes the app.
+begin
+  require_relative "../scripts/github_prv_repo_download_strategy"
+rescue LoadError
+  require "download_strategy"
+  unless defined?(GitHubPrivateRepositoryReleaseDownloadStrategy)
+    GitHubPrivateRepositoryReleaseDownloadStrategy = Class.new(CurlDownloadStrategy)
+  end
+end
 
 cask "cclog" do
   version "1.4.0"


### PR DESCRIPTION
This change makes the cclog cask resilient to a `LoadError` that occurs during `brew upgrade`. When upgrading, Homebrew copies the cask file alone into the Caskroom receipt without the sibling `scripts/` directory, causing `require_relative` to fail when loading the old version for uninstall.

**Download strategy fallback:**
* Wrapped the `require_relative` for the custom GitHub private repo download strategy in a `begin/rescue LoadError` block.
* Added a fallback stub that defines `GitHubPrivateRepositoryReleaseDownloadStrategy` as a subclass of `CurlDownloadStrategy` when the script cannot be loaded, so the receipt still loads and uninstall (which only quits and removes the app) succeeds without downloading.