### PR TITLE
chore(Formula): update ccs-picker to 1.5.1

### DIFF
--- a/Formula/ccs-picker.rb
+++ b/Formula/ccs-picker.rb
@@ -6,8 +6,8 @@ class CcsPicker < Formula
   desc "Fast, interactive terminal UI for browsing and resuming Claude sessions"
   homepage "https://github.com/benbenbang/ccs-picker"
   url "https://github.com/benbenbang/ccs-picker.git",
-      tag:      "1.5.0",
-      revision: "14e4fcf3575e12221bb628dfea334c3d680976e3"
+      tag:      "1.5.1",
+      revision: "2e6b9651a4e3f3dae08b2b5b642cb3b2da1e238c"
   license "MIT"
   head "https://github.com/benbenbang/ccs-picker.git", branch: "main"
 


### PR DESCRIPTION
Bump the ccs-picker formula to tag 1.5.1 with the corresponding revision to track the latest release.