### PR TITLE
fix(Casks): consolidate quit bundle ids into single uninstall

### DIFF
--- a/Casks/claudeisland.rb
+++ b/Casks/claudeisland.rb
@@ -25,8 +25,10 @@ cask "claudeisland" do
 
   app "Claude Island.app"
 
-  uninstall quit: "dev.bitbrew.claudeisland"
-  uninstall quit: "com.celestial.ClaudeIsland"
+  uninstall quit: [
+    "com.celestial.ClaudeIsland",
+    "dev.bitbrew.claudeisland",
+  ]
 
   zap trash: [
     "~/Library/Application Support/dev.bitbrew.claudeisland",


### PR DESCRIPTION
Merge the two separate `uninstall quit` declarations into one array so
both the current and legacy bundle identifiers are terminated on
uninstall, instead of the second declaration overriding the first.
